### PR TITLE
Docs: Add documentation for llms CLI command and review all docs

### DIFF
--- a/website/docs/api/plugin-options.md
+++ b/website/docs/api/plugin-options.md
@@ -94,15 +94,15 @@ Each session object has the following properties:
 ##### `sitemap`
 
     - **Type:** `string`
-    - **Required:** No (but typically provided if `type: "docs"`)
-    - **Description:** The path (relative to the Docusaurus project root) to the sitemap XML file. This is used for sessions of `type: "docs"` to discover pages.
+    - **Required:** No
+    - **Description:** The path (relative to the Docusaurus project root) to the sitemap XML file. This is used for sessions of `type: "docs"` to discover pages. If omitted for `type: "docs"`, the plugin may attempt to find all relevant document files (e.g., `.md`, `.mdx`) within the `docsDir`, but using a sitemap is recommended for accuracy and to respect Docusaurus' routing conventions.
     - **Example:** `"sitemap.xml"`
 
 ##### `rss`
 
     - **Type:** `string`
-    - **Required:** No (but typically provided if `type: "blog"`)
-    - **Description:** The path (relative to the Docusaurus project root) to the RSS feed XML file (usually `atom.xml` or `rss.xml`). This is used for sessions of `type: "blog"` to discover posts.
+    - **Required:** No
+    - **Description:** The path (relative to the Docusaurus project root) to the RSS feed XML file (usually `atom.xml` or `rss.xml`). This is used for sessions of `type: "blog"` to discover posts. If omitted for `type: "blog"`, the plugin may attempt to find all relevant content files (e.g., `.md`, `.mdx`) within the `docsDir`. However, providing an RSS feed is recommended for blog content.
     - **Example:** `"atom.xml"`
 
 ##### `patterns`
@@ -111,30 +111,32 @@ Each session object has the following properties:
     - **Required:** No
     - **Description:** An object that defines glob patterns for fine-grained control over which files are included or excluded, and their processing order.
     - **Properties:**
-      - `ignorePatterns`: `Array<string>` (可选)
-      - `orderPatterns`: `Array<string> | (a: string, b: string) => number` (Optional)
-        - Can be an array of glob strings, files will be arranged according to the order of these pattern matches. For example: `["**/introduction.md", "**/getting-started/**", "**/api/**"]`
-        - Can also be a custom sort function (SortFunction) that takes two file path parameters and returns a sort weight (negative means a comes first, positive means b comes first, 0 means order remains unchanged). For example:
+      - `ignorePatterns`: `Array<string>` (Optional) - Glob patterns for files/directories to exclude.
+      - `orderPatterns`: `Array<string> | ((a: string, b: string) => number)` (Optional)
+        - Can be an array of glob strings. Files matching these patterns will be ordered according to the sequence of patterns. For example: `["**/introduction.md", "**/getting-started/**", "**/api/**"]`.
+        - Can also be a custom sort function that takes two file path strings (relative to project root) and returns a number (`-1` for `a` first, `1` for `b` first, `0` for no change). For example:
           ```ts
           orderPatterns: (a, b) => a.length - b.length // Sort by path length in ascending order
           ```
-        - If both are set, the custom sort function takes precedence.
+        - If both array and function are provided, the custom sort function takes precedence.
+      - `includeUnmatched`: `boolean` (Optional, Default: `true`)
+        - If `orderPatterns` (array form) is used, this option determines how files not matching any `orderPatterns` are handled.
+        - If `true`, unmatched files are typically appended after the ordered files (their relative order might depend on filesystem or sitemap/RSS order).
+        - If `false`, only files explicitly matching an `orderPatterns` glob will be included in the session's output.
+        - This option has no effect if `orderPatterns` is a custom sort function or is not defined.
 
 #### `generateLLMsTxt`
 
 - **Type:** `boolean`
 - **Required:** No (Default: `false`)
-- **Description:** If set to `true`, the plugin will generate a `llms.txt` file. The exact content and purpose of this
-  file would ideally be further explained by the plugin's specific functionality (e.g., a concatenated text file for LLM
-  ingestion).
+- **Description:** If set to `true`, the plugin will generate a `llms.txt` file in the root directory of your Docusaurus project. This file typically contains a concatenated version of the text content from the configured sessions, optimized for ingestion by Large Language Models.
 - **Example:** `true`
 
 #### `generateLLMsFullTxt`
 
 - **Type:** `boolean`
 - **Required:** No (Default: `false`)
-- **Description:** If set to `true`, the plugin will generate a `llms_full.txt` file. Similar to `generateLLMsTxt`, this
-  likely produces a more comprehensive or differently formatted text output for LLMs.
+- **Description:** If set to `true`, the plugin will generate a `llms_full.txt` file in the root directory of your Docusaurus project. This file usually offers a more comprehensive or differently structured output compared to `llms.txt`, potentially including more metadata or closer fidelity to the original content.
 - **Example:** `true`
 
 #### `extraSession`

--- a/website/docs/guides/basic-usage.md
+++ b/website/docs/guides/basic-usage.md
@@ -106,6 +106,18 @@ After configuring the plugin and running your Docusaurus build process (e.g., `n
 
 You can then use these generated text files as input for your chosen LLM applications.
 
+## Using the `llms` CLI Command
+
+The Docusaurus LLMs Builder plugin provides a CLI command that allows you to generate the `llms.txt` and `llms-full.txt` files manually, without needing to run a full Docusaurus build. This can be useful for quick updates or when you only need to regenerate the LLM-specific files.
+
+To use the command, you can run it via `npx`:
+
+```bash
+npx docusaurus llms
+```
+
+This command will execute the LLMs Builder plugin based on your existing `docusaurus.config.js` configuration. The generated files (e.g., `llms.txt`, `llms_full.txt`) will be placed in the root directory of your Docusaurus project.
+
 ## Further Customization
 
 This is a basic example. The plugin offers many more options for fine-tuning how your content is processed. For a

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -34,6 +34,7 @@ LLM-driven tasks, this plugin provides the foundation by structuring and consoli
 - **Flexible Configuration**: Use glob patterns to include/exclude files and define processing order.
 - **Multiple Output Formats**: Generate summarized (`llms.txt`) and potentially full-text (`llms_full.txt`) versions of
   your content.
+- **CLI Command**: Manually generate LLM files using the `npx docusaurus llms` command for quick updates.
 - **Extensible**: Configure multiple instances for different parts of your site or different LLM tasks.
 - **Link Inclusion**: Add relevant external links to your LLM-processed content using the `extraSession` feature.
 


### PR DESCRIPTION
This commit introduces documentation for the `llms` CLI command in `website/docs/guides/basic-usage.md`. The new section explains how to use the command to generate `llms.txt` and `llms-full.txt` files manually.

Additionally, this commit includes a general review of all documentation files in `website/docs`. The following updates were made:

- Clarified plugin option descriptions in `website/docs/api/plugin-options.md`, including `patterns.includeUnmatched`, sitemap/RSS requirements, and output file locations for `generateLLMsTxt`/`generateLLMsFullTxt`.
- Added the `llms` CLI command to the "Key Features" list in `website/docs/intro.md`.
- Ensured consistency in the description of the `llms` CLI command output location in `website/docs/guides/basic-usage.md`.